### PR TITLE
chore: trigger build workflow only on merge to main

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
   build_and_deploy_job:


### PR DESCRIPTION
Remove pull_request trigger to prevent builds on PRs and only deploy when changes are merged to main branch