### PR TITLE
fix(ci): integrate build-and-deploy into release-please workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,9 +1,13 @@
-name: Build and Deploy to Azure Static Web Apps
+# This workflow has been integrated into release-please.yml
+# It will run automatically when a release is created
+# This file is kept for reference but is no longer used
+
+name: Build and Deploy to Azure Static Web Apps (DEPRECATED)
 
 on:
-  push:
-    tags:
-      - 'v*'
+  # This workflow is no longer triggered
+  # Build and deploy now happens in release-please.yml
+  workflow_dispatch: # Only manual trigger for testing
 
 jobs:
   build_and_deploy_job:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,3 +23,58 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: simple
+
+  build-and-deploy:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.releases_created }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create build directory
+        run: mkdir -p build
+
+      - name: Copy source files
+        run: cp -r src/* build/
+
+      - name: Install minification tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y minify
+
+      - name: Minify HTML files
+        run: |
+          for file in build/*.html; do
+            if [ -f "$file" ]; then
+              minify -o "${file}.min" "$file"
+              mv "${file}.min" "$file"
+            fi
+          done
+
+      - name: Minify CSS files
+        run: |
+          for file in build/css/*.css; do
+            if [ -f "$file" ]; then
+              minify -o "${file}.min" "$file"
+              mv "${file}.min" "$file"
+            fi
+          done
+
+      - name: Minify JavaScript files
+        run: |
+          for file in build/js/*.js; do
+            if [ -f "$file" ]; then
+              minify -o "${file}.min" "$file"
+              mv "${file}.min" "$file"
+            fi
+          done
+
+      - name: Deploy to Azure Static Web Apps
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: "upload"
+          app_location: "/build"
+          output_location: "/"


### PR DESCRIPTION
- Add build-and-deploy job to release-please.yml that triggers when releases are created
- Deprecate standalone build-and-deploy.yml workflow (kept for reference)
- Ensures deployment happens automatically when release-please creates new releases
- Fixes issue where build-and-deploy workflow didn't trigger on release tag creation