### PR TITLE
feat: add CODEOWNERS file and deployment status badge

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Global code owner - all files in this repository are owned by yelo
+* @yelo
+
+# Specific patterns for important files
+/.github/ @yelo
+/src/ @yelo
+README.md @yelo
+CHANGELOG.md @yelo

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 
 [![Release Please](https://github.com/yelo/jimmy.kumpulainen.se/actions/workflows/release-please.yml/badge.svg)](https://github.com/yelo/jimmy.kumpulainen.se/actions/workflows/release-please.yml)
 [![CodeQL](https://github.com/yelo/jimmy.kumpulainen.se/actions/workflows/codeql.yml/badge.svg)](https://github.com/yelo/jimmy.kumpulainen.se/actions/workflows/codeql.yml)
+[![Deployment Status](https://img.shields.io/github/deployments/yelo/jimmy.kumpulainen.se/production?label=deployment&logo=azure)](https://github.com/yelo/jimmy.kumpulainen.se/deployments)
 
 Welcome to the matrix, digital wanderer. This repository houses the source code for a cutting-edge CV website that exists at the intersection of artificial intelligence and pure neon-soaked cyberpunk aesthetics.
 


### PR DESCRIPTION
- Add CODEOWNERS file with @yelo as the global owner
- Add deployment status badge to README showing Azure Static Web Apps deployment status
- Improve project governance and visibility of deployment status