### PR TITLE
feat: neon glow mobile chaos mode

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -521,6 +521,13 @@ body::after {
 @media (max-width: 768px) {
     .glitch {
         font-size: 2rem;
+        max-width: 100vw;
+        overflow-wrap: break-word;
+        word-break: break-word;
+        white-space: normal;
+        padding: 0 10px;
+        text-align: center;
+        overflow: hidden;
     }
 
     .info-grid {
@@ -530,6 +537,15 @@ body::after {
     .contact-info {
         flex-direction: column;
         align-items: center;
+    }
+
+    .extreme-glitch-box {
+        margin: 18px 0;
+        padding: 12px 8px;
+        font-size: 1rem;
+        min-width: 0;
+        max-width: 98vw;
+        box-sizing: border-box;
     }
 }
 

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -650,9 +650,15 @@ body::after {
     overflow: hidden;
     margin: 30px 0;
     box-shadow:
-        0 0 30px rgba(255, 0, 255, 0.6),
-        inset 0 0 30px rgba(255, 0, 255, 0.2),
-        0 0 60px rgba(0, 255, 255, 0.3);
+        0 0 30px var(--neon-pink),
+        0 0 60px var(--neon-cyan),
+        0 0 90px var(--neon-yellow),
+        0 0 120px var(--neon-green),
+        0 0 30px 10px var(--neon-pink),
+        inset 0 0 40px var(--neon-cyan),
+        inset 0 0 60px var(--neon-yellow),
+        inset 0 0 80px var(--neon-green);
+    transition: box-shadow 0.3s, border-color 0.3s;
 }
 
 .extreme-glitch-box::before {

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -1,3 +1,80 @@
+/* Glitchy skill box effects */
+.skill {
+    position: relative;
+    overflow: hidden;
+    transition: filter 0.2s, box-shadow 0.2s;
+}
+
+.skill.glitchy {
+    filter: url('#pixelate'); /* fallback for pixelation */
+    animation: skillPixelate 0.35s steps(3, end);
+}
+
+.skill .skill-text {
+    position: relative;
+    z-index: 2;
+    color: #fff;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+}
+
+.skill.glitchy .skill-text {
+    animation: rgbSplit 0.35s steps(2, end);
+    text-shadow:
+        2px 0 2px #ff0000,
+        -2px 0 2px #00ff00,
+        0 2px 2px #00bfff;
+}
+
+.skill .scanlines {
+    pointer-events: none;
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    z-index: 3;
+    opacity: 0;
+    background: repeating-linear-gradient(
+        to bottom,
+        rgba(255,255,255,0.04) 0px,
+        rgba(255,255,255,0.04) 1px,
+        transparent 2px,
+        transparent 4px
+    );
+    transition: opacity 0.15s;
+}
+.skill.glitchy .scanlines {
+    opacity: 0.5;
+    animation: scanlineFlicker 0.35s steps(2, end);
+}
+
+@keyframes rgbSplit {
+    0% { text-shadow: none; }
+    30% {
+        text-shadow:
+            2px 0 2px #ff0000,
+            -2px 0 2px #00ff00,
+            0 2px 2px #00bfff;
+    }
+    70% {
+        text-shadow:
+            -2px 0 2px #ff0000,
+            2px 0 2px #00ff00,
+            0 -2px 2px #00bfff;
+    }
+    100% { text-shadow: none; }
+}
+
+@keyframes scanlineFlicker {
+    0% { opacity: 0.5; }
+    50% { opacity: 0.7; }
+    100% { opacity: 0.5; }
+}
+
+@keyframes skillPixelate {
+    0% { filter: blur(0px) contrast(1); }
+    40% { filter: blur(2px) contrast(1.2); }
+    60% { filter: blur(3px) contrast(1.3); }
+    100% { filter: blur(0px) contrast(1); }
+}
 /* Ultra-glitch chaos mode overlays */
 
 .ultra-glitch-gradient {

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -196,8 +196,10 @@ body::after {
     padding: 20px;
     margin: 20px 0;
     box-shadow:
-        0 0 20px rgba(0, 255, 255, 0.3),
-        inset 0 0 20px rgba(0, 255, 255, 0.1);
+        0 0 10px 2px rgba(0,255,255,0.22),
+        0 0 20px 4px rgba(0,255,255,0.16),
+        inset 0 0 14px rgba(0, 255, 255, 0.12);
+    animation: subtleNeonPulse 5s ease-in-out infinite;
     position: relative;
     overflow: hidden;
 }
@@ -241,7 +243,23 @@ body::after {
     border: 1px solid var(--neon-pink);
     padding: 15px;
     border-radius: 5px;
+    box-shadow: 0 0 7px 2px rgba(255,0,255,0.18);
+    animation: subtleNeonPulse 5s ease-in-out infinite;
     transition: all 0.3s ease;
+@keyframes subtleNeonPulse {
+    0% {
+        box-shadow: 0 0 7px 2px rgba(255,0,255,0.18), 0 0 10px 2px rgba(0,255,255,0.22);
+        filter: brightness(1.03);
+    }
+    50% {
+        box-shadow: 0 0 18px 5px rgba(255,0,255,0.28), 0 0 24px 6px rgba(0,255,255,0.22);
+        filter: brightness(1.13);
+    }
+    100% {
+        box-shadow: 0 0 7px 2px rgba(255,0,255,0.18), 0 0 10px 2px rgba(0,255,255,0.22);
+        filter: brightness(1.03);
+    }
+}
 }
 
 .info-item:hover {

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -666,15 +666,9 @@ body::after {
     overflow: hidden;
     margin: 30px 0;
     box-shadow:
-        0 0 30px var(--neon-pink),
-        0 0 60px var(--neon-cyan),
-        0 0 90px var(--neon-yellow),
-        0 0 120px var(--neon-green),
-        0 0 30px 10px var(--neon-pink),
-        inset 0 0 40px var(--neon-cyan),
-        inset 0 0 60px var(--neon-yellow),
-        inset 0 0 80px var(--neon-green);
-    transition: box-shadow 0.3s, border-color 0.3s;
+        0 0 30px rgba(255, 0, 255, 0.6),
+        inset 0 0 30px rgba(255, 0, 255, 0.2),
+        0 0 60px rgba(0, 255, 255, 0.3);
 }
 
 .extreme-glitch-box::before {

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -573,6 +573,25 @@ document.addEventListener('DOMContentLoaded', () => {
         const randomColor = colors[Math.floor(Math.random() * colors.length)];
         document.documentElement.style.setProperty('--grid-color', randomColor + '20');
     }, 5000);
+
+    // Mobile chaos/god mode trigger: long-press on main title
+    const mainTitle = document.querySelector('.glitch');
+    if (mainTitle) {
+        let touchTimer = null;
+        mainTitle.addEventListener('touchstart', function(e) {
+            if (godModeActivated) return;
+            touchTimer = setTimeout(() => {
+                godModeActivated = true;
+                initiateRealityBreach();
+            }, 1200); // 1.2s long-press
+        });
+        mainTitle.addEventListener('touchend', function(e) {
+            if (touchTimer) clearTimeout(touchTimer);
+        });
+        mainTitle.addEventListener('touchmove', function(e) {
+            if (touchTimer) clearTimeout(touchTimer);
+        });
+    }
 });
 
 // IDDQD neural override sequence (ancient god mode protocol)

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -72,12 +72,30 @@ function createMatrixRain() {
 function addGlitchEffect() {
     const skills = document.querySelectorAll('.skill');
     skills.forEach(skill => {
+        // Add scanlines overlay if not present
+        if (!skill.querySelector('.scanlines')) {
+            const scan = document.createElement('div');
+            scan.className = 'scanlines';
+            skill.appendChild(scan);
+        }
+
+        // Hover triggers glitchy effect
         skill.addEventListener('mouseenter', () => {
-            skill.style.animation = 'glitch 0.3s ease-in-out';
+            skill.classList.add('glitchy');
             setTimeout(() => {
-                skill.style.animation = '';
-            }, 300);
+                skill.classList.remove('glitchy');
+            }, 350);
         });
+
+        // Random idle glitching
+        setInterval(() => {
+            if (Math.random() < 0.12) { // ~12% chance every 3s
+                skill.classList.add('glitchy');
+                setTimeout(() => {
+                    skill.classList.remove('glitchy');
+                }, 350);
+            }
+        }, 3000 + Math.random() * 2000);
     });
 }
 


### PR DESCRIPTION
feat(style): add neon-like glow effect to extreme glitch box borders
fix(responsive): improve mobile sizing and prevent jumping for glitching title and boxes
feat(mobile): add long-press gesture to main title for chaos/god mode trigger on mobile
revert(style): restore original chaos box border and glow styles
feat(style): add subtle, slow pulsating neon glow to terminal and info-item boxes
feat(skill): add combined RGB split, scanline, and pixelation glitch effects to skill boxes (random and on hover)