### PR TITLE
feat: enhance chaos text overlays with CRT and RGB effects

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -744,7 +744,38 @@ body::after {
 }
 
 .chaos-text {
-    animation: chaosFloat 3s ease-in-out infinite, intensiveGlitch 1.5s linear infinite;
+    animation: chaosFloat 3s ease-in-out infinite, intensiveGlitch 1.5s linear infinite, crtFlicker 0.18s steps(2, end) infinite;
+    position: relative;
+    filter: contrast(1.4) brightness(1.1) blur(0.5px);
+    text-shadow:
+        2px 0 3px #ff0000,
+        -2px 0 3px #00ffea,
+        0 2px 3px #00ff00,
+        0 -2px 3px #ff00ea,
+        0 0 18px currentColor;
+}
+
+.chaos-text::after {
+    content: '';
+    position: absolute;
+    left: 0; top: 0; width: 100%; height: 100%;
+    pointer-events: none;
+    opacity: 0.18;
+    background: repeating-linear-gradient(
+        to bottom,
+        rgba(255,255,255,0.08) 0px,
+        rgba(255,255,255,0.08) 1px,
+        transparent 2px,
+        transparent 4px
+    );
+    z-index: 2;
+}
+
+@keyframes crtFlicker {
+    0% { filter: brightness(1.1) contrast(1.4); }
+    50% { filter: brightness(0.95) contrast(1.2); }
+    100% { filter: brightness(1.1) contrast(1.4); }
+/* End of crtFlicker keyframes */
 }
 
 /* Enhanced glitch status styling */


### PR DESCRIPTION
# Pull Request

## Summary
Enhances the floating chaos/glitch text overlays with CRT scanlines, RGB split, flicker, and distortion for a more cyberpunk and visually distorted look.

## Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Chore
- [ ] Other

## Related Issues
No related issues.

## Checklist
- [x] Conventional commit message
- [x] All tests and checks pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Additional Notes
This update makes the chaos mode overlays look much more like a broken CRT display, with RGB shifting and scanline effects layered in CSS.