### PR TITLE
chore: generalize AI assistants section to include multiple LLMs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,11 +35,11 @@ Refer to [Conventional Commits](https://www.conventionalcommits.org/) for detail
 
 This section lists the agents, bots, and automated systems involved in the development, deployment, or operation of this project.
 
-### GitHub Copilot
+### AI Assistants & LLMs
 
-- **Role:** AI coding assistant
-- **Purpose:** Assists with code generation, suggestions, and documentation
-- **Usage:** Integrated in VS Code for developer productivity
+- **Role:** AI coding assistants and language models
+- **Purpose:** Assist with code generation, suggestions, documentation, debugging, and general development tasks
+- **Usage:** Various AI tools including GitHub Copilot, Claude, ChatGPT, and other LLMs integrated across different development environments and workflows
 
 ### CI/CD Agents (if applicable)
 


### PR DESCRIPTION
## Summary
Updated the AGENTS.md file to generalize the AI assistants section from specifically mentioning GitHub Copilot to being more inclusive of various AI tools and LLMs used in development.

## Type of Change
- [ ] Bug fix
- [ ] Feature
- [x] Documentation
- [x] Chore
- [ ] Other

## Related Issues
<!-- List any related issues, e.g. Fixes #123 -->
N/A - Documentation improvement

## Checklist
- [x] Conventional commit message
- [x] All tests and checks pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Additional Notes
This change reflects the actual usage of multiple LLMs and AI assistants (GitHub Copilot, Claude, ChatGPT, etc.) across different development environments and workflows, making the documentation more accurate and technology-agnostic.