### PR TITLE
chore: trigger CodeQL analysis only on approved pull request reviews

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,7 +19,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    if: github.event_name != 'pull_request_review' || github.event.review.state == 'approved
+    if: github.event_name != 'pull_request_review' || github.event.review.state == 'approved'
 
     strategy:
       fail-fast: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,11 +2,13 @@ name: "CodeQL Security Analysis"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
+  pull_request_review:
+    types: [submitted]
   schedule:
-    - cron: '42 15 * * 1'  # Weekly scan on Mondays
+    - cron: "42 15 * * 1" # Weekly scan on Mondays
 
 jobs:
   analyze:
@@ -17,25 +19,26 @@ jobs:
       actions: read
       contents: read
       security-events: write
+    if: github.event_name != 'pull_request_review' || github.event.review.state == 'approved
 
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
+        language: ["javascript"]
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
 
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"


### PR DESCRIPTION
# Pull Request

## Summary
This PR updates the CodeQL workflow to trigger analysis only when a pull request review is approved.  
- Adds `pull_request_review` event to the workflow trigger.
- Ensures the job runs only if the review state is "approved" using conditional logic.

## Type of Change
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [X] Chore
- [ ] Other

## Related Issues
<!-- List any related issues, e.g. Fixes #123 -->

## Checklist
- [X] Conventional commit message
- [X] All tests and checks pass
- [ ] Documentation updated (if needed)
- [X] Ready for review

## Additional Notes
No additional notes.
