### PR TITLE
feat(ux): add fun animation to work history

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -339,9 +339,23 @@ footer {
     to { transform: rotate(360deg) scale(1.5); }
 }
 
-.job.job-clicked {
-    transform: scale(1.03);
-    background-color: var(--background-color); /* Aquamarine */
+.character-particle {
+    position: fixed;
+    pointer-events: none;
+    z-index: 10001;
+    font-size: 24px;
+    animation: character-explode 1s ease-out forwards;
+}
+
+@keyframes character-explode {
+    0% {
+        transform: translate(0, 0) rotate(0deg) scale(1);
+        opacity: 1;
+    }
+    100% {
+        transform: translate(var(--x), var(--y)) rotate(var(--r)) scale(0);
+        opacity: 0;
+    }
 }
 
 .header-decoration {

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -201,16 +201,43 @@ function addSkillInteractivity() {
 function addJobInteractivity() {
     const jobs = document.querySelectorAll('.job');
     jobs.forEach(job => {
-        job.addEventListener('click', () => {
-            // Prevent effect in matrix mode
+        job.addEventListener('click', (e) => {
             if (document.body.classList.contains('matrix-mode')) return;
 
-            job.classList.add('job-clicked');
-            setTimeout(() => {
-                job.classList.remove('job-clicked');
-            }, 400); // Timeout should be longer than the transition
+            // Create the explosion at the cursor's location
+            const x = e.clientX;
+            const y = e.clientY;
+
+            for (let i = 0; i < 30; i++) {
+                createCharacterParticle(x, y);
+            }
         });
     });
+}
+
+function createCharacterParticle(x, y) {
+    const characters = ['🐬', '✨', '💖', '⭐', '🚀'];
+    const character = characters[Math.floor(Math.random() * characters.length)];
+
+    const particle = document.createElement('div');
+    particle.className = 'character-particle';
+    particle.textContent = character;
+    document.body.appendChild(particle);
+
+    particle.style.left = `${x}px`;
+    particle.style.top = `${y}px`;
+
+    const angle = Math.random() * 360;
+    const distance = Math.random() * 100 + 50;
+    const rotation = Math.random() * 720 - 360;
+
+    particle.style.setProperty('--x', `${Math.cos(angle * Math.PI / 180) * distance}px`);
+    particle.style.setProperty('--y', `${Math.sin(angle * Math.PI / 180) * distance}px`);
+    particle.style.setProperty('--r', `${rotation}deg`);
+
+    setTimeout(() => {
+        particle.remove();
+    }, 1000);
 }
 
 function createParticle(x, y) {


### PR DESCRIPTION
# Pull Request

## Summary
This PR replaces the simple click effect on work history items with a fun, new particle explosion animation.

## Task and Thought Process

### The Task
The user wanted to replace the "boring" click animation on work history items with something "funnier", inspired by the skill item animation but not a direct copy. The explosion should originate from the cursor's location.

### Thought Process
1.  Analyzed the existing `addJobInteractivity` and `addSkillInteractivity` functions to understand the current implementation.
2.  Decided to create a "character explosion" effect using emojis (🐬, ✨, 💖, ⭐, 🚀) to fit the site's aesthetic.
3.  Implemented the new animation in `script.js` by creating a `createCharacterParticle` function and updating `addJobInteractivity`.
4.  Added corresponding styles for the `character-particle` and its animation in `styles.css`, and removed the old `.job-clicked` style.
5.  Initially, the explosion originated from the center of the element. Based on user feedback, I updated it to originate from the cursor's position for a more interactive feel.

## Type of Change
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore
- [ ] Other

## Related Issues
<!-- List any related issues, e.g. Fixes #123 -->

## Checklist
- [x] Conventional commit message
- [x] All tests and checks pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Additional Notes
I'm glad you like it! <3
